### PR TITLE
Add renv infrastructure

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 dev_history.R
 ^dev$
 $run_dev.*
+^renv$
+^renv\.lock$

--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinylego
 Title: Shiny application for creating LEGO mosiacs
-Version: 0.0.0.9000
+Version: 0.1.0.9000
 Authors@R: c(
   person('Eric', 'Nantz', email = 'thercast@gmail.com', role = c('cre', 'aut')),
   person('Ryan', 'Timpe', role = c('ctb'))
@@ -25,7 +25,7 @@ Imports:
     shinipsum (>= 0.0.0.9000),
     magrittr,
     magick,
-    bs4Dash (>= 0.3.0),
+    bs4Dash,
     fs,
     shinyWidgets,
     shinycustomloader,
@@ -40,6 +40,5 @@ Suggests:
     rgl,
 Roxygen: list(markdown = TRUE)
 Remotes: 
-    Thinkr-open/shinipsum,
-    RinteRface/bs4Dash
+    Thinkr-open/shinipsum
 RoxygenNote: 6.1.1

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -195,6 +195,7 @@ app_ui <- function() {
             fluidRow(
               col_6(
                 bs4TabCard(
+                  id = "bricks_req",
                   title = "Bricks Required",
                   status = NULL,
                   solidHeader = FALSE,

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -3,7 +3,7 @@
 app_ui <- function() {
   tagList(
     golem_add_external_resources(),
-    golem::js(),
+    golem::activate_js(),
     bs4DashPage(
       title = "ShinyLEGO",
       sidebar_collapsed = FALSE,

--- a/README.Rmd
+++ b/README.Rmd
@@ -27,7 +27,7 @@ This application would not be possible without the innovative R scripts created 
 
 ## Installation
 
-You can install the development version of `shinylego` from [GitHub](https://gitlab.com) with:
+You can install the development version of `shinylego` from [GitHub](https://github.com) with:
 
 ``` r
 # install.packages("remotes")
@@ -44,7 +44,17 @@ shinylego::run_app()
 
 ## Deployments
 
-`shinylego` is also available on the Shinyapps.io hosting service at [rpodcast.shinyapps.io/shinylego](https://rpodcast.shinyapps.io/shinylego)
+`shinylego` is also available on the Shinyapps.io hosting service at [rpodcast.shinyapps.io/shinylego](https://rpodcast.shinyapps.io/shinylego).  
+
+__Note for developer__: The deployment should not include files associated with [`renv`](https://rstudio.github.io/renv/), since the __shinyapps.io__ service will handle package versions during the deployment process.  Add the files/directories required for deployment in the `dev/app_manifest.txt` file, and execute deployment with the following:
+
+```r
+rsconnect::deployApp(appName = "shinylego", appFileManifest = "dev/app_manifest.txt", launch.browser = FALSE)
+```
+
+## Development
+
+Contributions are welcome! This application uses the [`renv`](https://rstudio.github.io/renv/) package to manage the versions of dependencies. After cloning the repository, launch a new session in the repository root directory and execute `renv::restore()` to download the package library.   
 
 ## Acknowlegements
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repository](https://github.com/ryantimpe/LEGOMosaics):
 ## Installation
 
 You can install the development version of `shinylego` from
-[GitHub](https://gitlab.com) with:
+[GitHub](https://github.com) with:
 
 ``` r
 # install.packages("remotes")
@@ -49,7 +49,26 @@ shinylego::run_app()
 ## Deployments
 
 `shinylego` is also available on the Shinyapps.io hosting service at
-[rpodcast.shinyapps.io/shinylego](https://rpodcast.shinyapps.io/shinylego)
+[rpodcast.shinyapps.io/shinylego](https://rpodcast.shinyapps.io/shinylego).
+
+**Note for developer**: The deployment should not include files
+associated with [`renv`](https://rstudio.github.io/renv/), since the
+**shinyapps.io** service will handle package versions during the
+deployment process. Add the files/directories required for deployment in
+the `dev/app_manifest.txt` file, and execute deployment with the
+following:
+
+``` r
+rsconnect::deployApp(appName = "shinylego", appFileManifest = "dev/app_manifest.txt", launch.browser = FALSE)
+```
+
+## Development
+
+Contributions are welcome\! This application uses the
+[`renv`](https://rstudio.github.io/renv/) package to manage the versions
+of dependencies. After cloning the repository, launch a new session in
+the repository root directory and execute `renv::restore()` to download
+the package library.
 
 ## Acknowlegements
 

--- a/dev/app_manifest.txt
+++ b/dev/app_manifest.txt
@@ -1,0 +1,12 @@
+app.R
+DESCRIPTION
+inst
+man
+NAMESPACE
+NEWS.md
+R
+README.md
+README.Rmd
+data-raw
+data
+tests

--- a/renv.lock
+++ b/renv.lock
@@ -1,0 +1,1182 @@
+{
+  "renv": {
+    "Version": "0.6.0-92"
+  },
+  "R": {
+    "Version": "3.6.1",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cloud.r-project.org"
+      }
+    ]
+  },
+  "Packages": {
+    "askpass": {
+      "Package": "askpass",
+      "Version": "1.1",
+      "Source": "CRAN",
+      "Hash": "46678e19f261db289be40292d8e5d5bf"
+    },
+    "assertthat": {
+      "Package": "assertthat",
+      "Version": "0.2.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "assertthat",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.2.1",
+      "Hash": "19fb3d0ad048b4eb1a05cacffbae1f66"
+    },
+    "attempt": {
+      "Package": "attempt",
+      "Version": "0.3.0",
+      "Source": "CRAN",
+      "Hash": "abccf986dbdc6ae32ee72d0107ba7587"
+    },
+    "backports": {
+      "Package": "backports",
+      "Version": "1.1.4",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "backports",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.1.4",
+      "Hash": "2a78bf0825e0088e117520553ceb7fa5"
+    },
+    "base64enc": {
+      "Package": "base64enc",
+      "Version": "0.1-3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "base64enc",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.1-3",
+      "Hash": "d355963b4b1c3039bfe8d65611a11cca"
+    },
+    "BH": {
+      "Package": "BH",
+      "Version": "1.69.0-1",
+      "Source": "CRAN",
+      "Hash": "0fde015f5153e51df44981da0767f522"
+    },
+    "bmp": {
+      "Package": "bmp",
+      "Version": "0.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "bmp",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.3",
+      "Hash": "de24ef5df8126f89b9cdc1d670470612"
+    },
+    "brew": {
+      "Package": "brew",
+      "Version": "1.0-6",
+      "Source": "CRAN",
+      "Hash": "190fd31e9253446523a8ee4642229516"
+    },
+    "bs4Dash": {
+      "Package": "bs4Dash",
+      "Version": "0.4.0",
+      "Source": "CRAN",
+      "Hash": "f0f263d40617cb70d093111bbbc154d8"
+    },
+    "Cairo": {
+      "Package": "Cairo",
+      "Version": "1.5-10",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "Cairo",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.5-10",
+      "Hash": "96f52d02dec05b1e6585ac27a915ff0e"
+    },
+    "callr": {
+      "Package": "callr",
+      "Version": "3.3.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "callr",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "3.3.1",
+      "Hash": "b9788f81c78e3187d199c4057872fe06"
+    },
+    "cli": {
+      "Package": "cli",
+      "Version": "1.1.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "cli",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.1.0",
+      "Hash": "9b3dc7798f53ba3050b41ce4a3febdc5"
+    },
+    "clipr": {
+      "Package": "clipr",
+      "Version": "0.7.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "clipr",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.7.0",
+      "Hash": "9a99b54d2baf9393d0a68b6ea9513ee6"
+    },
+    "clisymbols": {
+      "Package": "clisymbols",
+      "Version": "1.2.0",
+      "Source": "CRAN",
+      "Hash": "ce91c46caba29e30c44cfd87659bf8a4"
+    },
+    "codetools": {
+      "Package": "codetools",
+      "Version": "0.2-16",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "codetools",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.2-16",
+      "Hash": "3bf2a0853d7faf7f865d0b877946e452"
+    },
+    "colorspace": {
+      "Package": "colorspace",
+      "Version": "1.4-1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "colorspace",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.4-1",
+      "Hash": "c25d49739abb6ebf4b3d0c3565574226"
+    },
+    "commonmark": {
+      "Package": "commonmark",
+      "Version": "1.7",
+      "Source": "CRAN",
+      "Hash": "af7f698e0328e0474f794452177deca6"
+    },
+    "crayon": {
+      "Package": "crayon",
+      "Version": "1.3.4",
+      "Source": "CRAN",
+      "Hash": "d308ead32010b8e4d76c4690427da50b"
+    },
+    "crosstalk": {
+      "Package": "crosstalk",
+      "Version": "1.0.0",
+      "Source": "CRAN",
+      "Hash": "2bc962d85f29df259cc1a6930727ce87"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "4.0",
+      "Source": "CRAN",
+      "Hash": "7dc1d02a04a75510424d2c7404fadfa7"
+    },
+    "data.table": {
+      "Package": "data.table",
+      "Version": "1.12.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "data.table",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.12.2",
+      "Hash": "f2f76b5c5394350c4d4ee77dab51d35c"
+    },
+    "desc": {
+      "Package": "desc",
+      "Version": "1.2.0",
+      "Source": "CRAN",
+      "Hash": "0119aa659b9c1db195b4bd7c617d18c0"
+    },
+    "devtools": {
+      "Package": "devtools",
+      "Version": "2.1.0",
+      "Source": "CRAN",
+      "Hash": "30e711b77a5bfa480161015ead405a0d"
+    },
+    "digest": {
+      "Package": "digest",
+      "Version": "0.6.20",
+      "Source": "CRAN",
+      "Hash": "e90f6670040b5aec92425051fc13ac1c"
+    },
+    "dockerfiler": {
+      "Package": "dockerfiler",
+      "Version": "0.1.3",
+      "Source": "CRAN",
+      "Hash": "2fa7e591556180db4964ea761268af7c"
+    },
+    "doParallel": {
+      "Package": "doParallel",
+      "Version": "1.0.15",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "doParallel",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.0.15",
+      "Hash": "ea9dc2ce170b1a53ba64f0b869664501"
+    },
+    "downloader": {
+      "Package": "downloader",
+      "Version": "0.4",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "downloader",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.4",
+      "Hash": "49907781ae2617dd5481b7c21a426d08"
+    },
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "0.8.3",
+      "Source": "CRAN",
+      "Hash": "17783831e1e918ab250dcae5dd9c6e03"
+    },
+    "DT": {
+      "Package": "DT",
+      "Version": "0.8",
+      "Source": "CRAN",
+      "Hash": "f3c8ebf07b488feb5045a1ca7cd398b2"
+    },
+    "dygraphs": {
+      "Package": "dygraphs",
+      "Version": "1.1.1.6",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "dygraphs",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.1.1.6",
+      "Hash": "aba5ded396338b13e4458d0cb0c2ec86"
+    },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.2.0.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "ellipsis",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.2.0.1",
+      "Hash": "a7a9b2ae023bf012744c480d3388c0c8"
+    },
+    "evaluate": {
+      "Package": "evaluate",
+      "Version": "0.14",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "evaluate",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.14",
+      "Hash": "5a6c1949963e0785dbcbb0556337d61e"
+    },
+    "fansi": {
+      "Package": "fansi",
+      "Version": "0.4.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "fansi",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.4.0",
+      "Hash": "cd87b0162287f0da225edfaa2fd3a20c"
+    },
+    "foreach": {
+      "Package": "foreach",
+      "Version": "1.4.7",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "foreach",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.4.7",
+      "Hash": "679941326860ea87464d7f010341fb05"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.3.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "fs",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.3.1",
+      "Hash": "dba7e43c4103d978cb7c95b97987cc68"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.2.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "ggplot2",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "3.2.1",
+      "Hash": "635db021d29f3523c4f88e82d0c01c5e"
+    },
+    "gh": {
+      "Package": "gh",
+      "Version": "1.0.1",
+      "Source": "CRAN",
+      "Hash": "3fc5d4d6893bd1598318a35def5e9d23"
+    },
+    "git2r": {
+      "Package": "git2r",
+      "Version": "0.26.1",
+      "Source": "CRAN",
+      "Hash": "22ea14e8f582d4a83a273f24ac43e27e"
+    },
+    "glue": {
+      "Package": "glue",
+      "Version": "1.3.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "glue",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.3.1",
+      "Hash": "e8436e647719b7c9d01409767cd88cc8"
+    },
+    "golem": {
+      "Package": "golem",
+      "Version": "0.1",
+      "Source": "CRAN",
+      "Hash": "bca2a5efeb4be5f492327956f4117071"
+    },
+    "gtable": {
+      "Package": "gtable",
+      "Version": "0.3.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "gtable",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.3.0",
+      "Hash": "6a58b2980a57345822ec5f9c7d2d1751"
+    },
+    "hexbin": {
+      "Package": "hexbin",
+      "Version": "1.27.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "hexbin",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.27.3",
+      "Hash": "dd1a219a8e8212b1808640670893274e"
+    },
+    "highr": {
+      "Package": "highr",
+      "Version": "0.8",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "highr",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.8",
+      "Hash": "43e36bc8bca1d8256f86933659c46349"
+    },
+    "hms": {
+      "Package": "hms",
+      "Version": "0.5.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "hms",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.5.1",
+      "Hash": "5c9cbb0d6f49109be1a771d963801847"
+    },
+    "htmltools": {
+      "Package": "htmltools",
+      "Version": "0.3.6",
+      "Source": "CRAN",
+      "Hash": "5132526e7fb28a2c20d1ef443d5c4644"
+    },
+    "htmlwidgets": {
+      "Package": "htmlwidgets",
+      "Version": "1.3",
+      "Source": "CRAN",
+      "Hash": "8aa0ed21f14fc9645367e8bc305415f5"
+    },
+    "httpuv": {
+      "Package": "httpuv",
+      "Version": "1.5.1",
+      "Source": "CRAN",
+      "Hash": "3e4206eb62d89401a2a990eba9b3ecac"
+    },
+    "httr": {
+      "Package": "httr",
+      "Version": "1.4.1",
+      "Source": "CRAN",
+      "Hash": "5dbd937df2ed15043fd4b49e1e217030"
+    },
+    "igraph": {
+      "Package": "igraph",
+      "Version": "1.2.4.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "igraph",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.2.4.1",
+      "Hash": "6eb7a604bc33c66dac0611b7ce75ac69"
+    },
+    "imager": {
+      "Package": "imager",
+      "Version": "0.41.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "imager",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.41.2",
+      "Hash": "8ef6e00f4445a4214e8ba093b2415741"
+    },
+    "ini": {
+      "Package": "ini",
+      "Version": "0.3.1",
+      "Source": "CRAN",
+      "Hash": "4a15d8cfc931554fb2e71d66c1313b45"
+    },
+    "iterators": {
+      "Package": "iterators",
+      "Version": "1.0.12",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "iterators",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.0.12",
+      "Hash": "30ef58a17d970ae05c85793da79152d6"
+    },
+    "jpeg": {
+      "Package": "jpeg",
+      "Version": "0.1-8",
+      "Source": "CRAN",
+      "Hash": "c5744e03e8ed29c1b66dc47d6cf1b2c8"
+    },
+    "jsonlite": {
+      "Package": "jsonlite",
+      "Version": "1.6",
+      "Source": "CRAN",
+      "Hash": "b7e67b6a7bc2fdae729c0f3ff9026a8a"
+    },
+    "knitr": {
+      "Package": "knitr",
+      "Version": "1.24",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "knitr",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.24",
+      "Hash": "4d5213d0ec43d3ef3415177faa434602"
+    },
+    "labeling": {
+      "Package": "labeling",
+      "Version": "0.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "labeling",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.3",
+      "Hash": "e1f613894f080d1eee41c34b281a2184"
+    },
+    "later": {
+      "Package": "later",
+      "Version": "0.8.0",
+      "Source": "CRAN",
+      "Hash": "4d5b806a328e0da75f0f0d4653676552"
+    },
+    "lattice": {
+      "Package": "lattice",
+      "Version": "0.20-38",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "lattice",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.20-38",
+      "Hash": "6f7aa123115b33bc9ad1ca800874b1de"
+    },
+    "lazyeval": {
+      "Package": "lazyeval",
+      "Version": "0.2.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "lazyeval",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.2.2",
+      "Hash": "d2f5e98b8b7ae633e252830c3243c2ab"
+    },
+    "magick": {
+      "Package": "magick",
+      "Version": "2.1",
+      "Source": "CRAN",
+      "Hash": "4f74e544addf4174c17109772326d136"
+    },
+    "magrittr": {
+      "Package": "magrittr",
+      "Version": "1.5",
+      "Source": "CRAN",
+      "Hash": "dee1d97cffddfd3ed969e224bd0826d0"
+    },
+    "manipulateWidget": {
+      "Package": "manipulateWidget",
+      "Version": "0.10.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "manipulateWidget",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.10.0",
+      "Hash": "5d218991510284dcf19b4d5cce6223aa"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "markdown",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.1",
+      "Hash": "80e1f73841614fa35f82a85d66fb41da"
+    },
+    "MASS": {
+      "Package": "MASS",
+      "Version": "7.3-51.4",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "MASS",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "7.3-51.4",
+      "Hash": "a489ad42493fa9bfac8f3e3a3bc7d4ca"
+    },
+    "Matrix": {
+      "Package": "Matrix",
+      "Version": "1.2-17",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "Matrix",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.2-17",
+      "Hash": "a60009c832f495604f54399f21d89cc8"
+    },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "1.1.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "memoise",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.1.0",
+      "Hash": "22ca9b285c10f5dd8c4d1e90231ce558"
+    },
+    "mgcv": {
+      "Package": "mgcv",
+      "Version": "1.8-28",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "mgcv",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.8-28",
+      "Hash": "6ac256e4fdcf33c11f9ed987927cc614"
+    },
+    "mime": {
+      "Package": "mime",
+      "Version": "0.7",
+      "Source": "CRAN",
+      "Hash": "908d95ccbfd1dd274073ef07a7c93934"
+    },
+    "miniUI": {
+      "Package": "miniUI",
+      "Version": "0.1.1.1",
+      "Source": "CRAN",
+      "Hash": "53236ac4d8dcc50446bbb83c45e024cd"
+    },
+    "munsell": {
+      "Package": "munsell",
+      "Version": "0.5.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "munsell",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.5.0",
+      "Hash": "9111af6c6dec65538ebd3de6c0bae864"
+    },
+    "nlme": {
+      "Package": "nlme",
+      "Version": "3.1-141",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "nlme",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "3.1-141",
+      "Hash": "be8db89838a17117a4083e72350443e0"
+    },
+    "openssl": {
+      "Package": "openssl",
+      "Version": "1.4.1",
+      "Source": "CRAN",
+      "Hash": "6c438de366d5693238d1c400deb66cb6"
+    },
+    "packrat": {
+      "Package": "packrat",
+      "Version": "0.5.0",
+      "Source": "CRAN",
+      "Hash": "aa1fbebb6ca276f933b9f77da6d02ef3"
+    },
+    "pillar": {
+      "Package": "pillar",
+      "Version": "1.4.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "pillar",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.4.2",
+      "Hash": "57645ff795277554eee14df5bcee8025"
+    },
+    "pkgbuild": {
+      "Package": "pkgbuild",
+      "Version": "1.0.4",
+      "Source": "CRAN",
+      "Hash": "efbc9215b1e6453aa0417bf5516c260b"
+    },
+    "pkgconfig": {
+      "Package": "pkgconfig",
+      "Version": "2.0.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "pkgconfig",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "2.0.2",
+      "Hash": "2dd2d8867e4f0173ea2ce029d630a086"
+    },
+    "pkgload": {
+      "Package": "pkgload",
+      "Version": "1.0.2",
+      "Source": "CRAN",
+      "Hash": "f214a72af3442fdd3396ceccbb7d7f44"
+    },
+    "plogr": {
+      "Package": "plogr",
+      "Version": "0.2.0",
+      "Source": "CRAN",
+      "Hash": "1a8304cc1382ef64e3b710ba589d7bc0"
+    },
+    "plotly": {
+      "Package": "plotly",
+      "Version": "4.9.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "plotly",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "4.9.0",
+      "Hash": "d4f8ca9fa024657598c3698df2e12cfb"
+    },
+    "plyr": {
+      "Package": "plyr",
+      "Version": "1.8.4",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "plyr",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.8.4",
+      "Hash": "37dd0f3aadee2ac99e47168f4bffddb7"
+    },
+    "png": {
+      "Package": "png",
+      "Version": "0.1-7",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "png",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.1-7",
+      "Hash": "2facb7d8929420c91d1ddc8d4636f787"
+    },
+    "praise": {
+      "Package": "praise",
+      "Version": "1.0.0",
+      "Source": "CRAN",
+      "Hash": "3940f2f321d5fa9fb72b8887b0454660"
+    },
+    "prettyunits": {
+      "Package": "prettyunits",
+      "Version": "1.0.2",
+      "Source": "CRAN",
+      "Hash": "33ce93b23647e85c127f8e1bb08604fc"
+    },
+    "processx": {
+      "Package": "processx",
+      "Version": "3.4.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "processx",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "3.4.1",
+      "Hash": "fec9b1a798e49d0609702929706a1dfc"
+    },
+    "progress": {
+      "Package": "progress",
+      "Version": "1.2.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "progress",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.2.2",
+      "Hash": "e8c47e04650b07d40c3c50a878a4dffa"
+    },
+    "promises": {
+      "Package": "promises",
+      "Version": "1.0.1",
+      "Source": "CRAN",
+      "Hash": "f80d162b7cef7e36a0134d1f1084e36d"
+    },
+    "ps": {
+      "Package": "ps",
+      "Version": "1.3.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "ps",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.3.0",
+      "Hash": "a38f3fd447d1595a3da538910054b911"
+    },
+    "purrr": {
+      "Package": "purrr",
+      "Version": "0.3.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "purrr",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.3.2",
+      "Hash": "c360ab7eabd6e38a83f2475eb97c6344"
+    },
+    "R6": {
+      "Package": "R6",
+      "Version": "2.4.0",
+      "Source": "CRAN",
+      "Hash": "92b50d943a7c76c67918c1e1beb68627"
+    },
+    "raster": {
+      "Package": "raster",
+      "Version": "3.0-2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "raster",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "3.0-2",
+      "Hash": "d5b06cb254bf33f72bd966c54ae3237a"
+    },
+    "rayshader": {
+      "Package": "rayshader",
+      "Version": "0.11.5",
+      "Source": "CRAN",
+      "Hash": "87cca0114aae55981ef58496eeb6850f"
+    },
+    "rcmdcheck": {
+      "Package": "rcmdcheck",
+      "Version": "1.3.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "rcmdcheck",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.3.3",
+      "Hash": "577b91be8aea851ea27aad3585adef05"
+    },
+    "RColorBrewer": {
+      "Package": "RColorBrewer",
+      "Version": "1.1-2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "RColorBrewer",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.1-2",
+      "Hash": "f8a3bcc800d613797f1dfdf8ef4f0bfc"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.0.2",
+      "Source": "CRAN",
+      "Hash": "c25fa7d5684fa7001ddfea3755243975"
+    },
+    "RcppArmadillo": {
+      "Package": "RcppArmadillo",
+      "Version": "0.9.600.4.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "RcppArmadillo",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.9.600.4.0",
+      "Hash": "57ecd65f250da202aa6c618074bcdb30"
+    },
+    "readbitmap": {
+      "Package": "readbitmap",
+      "Version": "0.1.5",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "readbitmap",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.1.5",
+      "Hash": "68412c72e5b7bcd64eb42c195410c6e3"
+    },
+    "readr": {
+      "Package": "readr",
+      "Version": "1.3.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "readr",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.3.1",
+      "Hash": "60167b7ec3de99e76ff406aaf0f83bb4"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.1.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "remotes",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "2.1.0",
+      "Hash": "830aa73278dce9beba583bfe57a5c015"
+    },
+    "reshape2": {
+      "Package": "reshape2",
+      "Version": "1.4.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "reshape2",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.4.3",
+      "Hash": "ac685130d1a25e3f6470960fd29c5693"
+    },
+    "rgl": {
+      "Package": "rgl",
+      "Version": "0.100.30",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "rgl",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.100.30",
+      "Hash": "da84f974fbb703b936cbb7644b1bfc4a"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "0.4.0",
+      "Source": "CRAN",
+      "Hash": "8f1bf3a54c8844dc254baabba61cb6a9"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "1.14",
+      "Source": "CRAN",
+      "Hash": "b712ba012c5d17214b872a47f40a611e"
+    },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "6.1.1",
+      "Source": "CRAN",
+      "Hash": "5c44ac973ec9b56efd7990e4b4464699"
+    },
+    "rprojroot": {
+      "Package": "rprojroot",
+      "Version": "1.3-2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "rprojroot",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.3-2",
+      "Hash": "5382761b8b318da6dd3fb0f6dae3c43a"
+    },
+    "rsconnect": {
+      "Package": "rsconnect",
+      "Version": "0.8.15",
+      "Source": "CRAN",
+      "Hash": "649b33e97eb02dc7f8533a50d888ae29"
+    },
+    "rstudioapi": {
+      "Package": "rstudioapi",
+      "Version": "0.10",
+      "Source": "CRAN",
+      "Hash": "04552808fd065fdf0fec7bad340eb83c"
+    },
+    "scales": {
+      "Package": "scales",
+      "Version": "1.0.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "scales",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.0.0",
+      "Hash": "a96e9571cd875b7b934990d85b7a3c18"
+    },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.1.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "sessioninfo",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.1.1",
+      "Hash": "017efbc7877606b886a2fb3d01c0bbda"
+    },
+    "shinipsum": {
+      "Package": "shinipsum",
+      "Version": "0.0.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "shinipsum",
+      "RemoteUsername": "Thinkr-open",
+      "RemoteRef": "master",
+      "RemoteSha": "7092c5e285bd48dc5fde9b461ce28dfdd00e3c4a",
+      "Hash": "d7f8afe205c345142fd2ef362655b6e0"
+    },
+    "shiny": {
+      "Package": "shiny",
+      "Version": "1.3.2",
+      "Source": "CRAN",
+      "Hash": "3f96ad878877e005bcf6093c5c7efd9e"
+    },
+    "shinycustomloader": {
+      "Package": "shinycustomloader",
+      "Version": "0.9.0",
+      "Source": "CRAN",
+      "Hash": "44855d5a7750e961b69e347f8190dc9c"
+    },
+    "shinyjs": {
+      "Package": "shinyjs",
+      "Version": "1.0",
+      "Source": "CRAN",
+      "Hash": "f80ba8b88aa5cd27157e8cd3bbd7cc35"
+    },
+    "shinyWidgets": {
+      "Package": "shinyWidgets",
+      "Version": "0.4.8",
+      "Source": "CRAN",
+      "Hash": "9fba9f0d9fc4482c1d679b5b977a69fc"
+    },
+    "sourcetools": {
+      "Package": "sourcetools",
+      "Version": "0.1.7",
+      "Source": "CRAN",
+      "Hash": "fc68fa34b8576eaa5a845a46ad75e214"
+    },
+    "sp": {
+      "Package": "sp",
+      "Version": "1.3-1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "sp",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.3-1",
+      "Hash": "a8e1d618f252db052d85391d528c256f"
+    },
+    "stringi": {
+      "Package": "stringi",
+      "Version": "1.4.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "stringi",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.4.3",
+      "Hash": "113506f116db9dd5bd1caf46884e0647"
+    },
+    "stringr": {
+      "Package": "stringr",
+      "Version": "1.4.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "stringr",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "1.4.0",
+      "Hash": "41d6310ad18bd019a203d7adc496a28b"
+    },
+    "sys": {
+      "Package": "sys",
+      "Version": "3.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "sys",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "3.3",
+      "Hash": "9ecf6bee5958b8977bd1db3131978a71"
+    },
+    "testthat": {
+      "Package": "testthat",
+      "Version": "2.2.1",
+      "Source": "CRAN",
+      "Hash": "3e86adb988cb96c5b30b01ec56719ac4"
+    },
+    "tibble": {
+      "Package": "tibble",
+      "Version": "2.1.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "tibble",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "2.1.3",
+      "Hash": "a8d41bd284e21ab7e776d228dc5bac91"
+    },
+    "tidyr": {
+      "Package": "tidyr",
+      "Version": "0.8.3",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "tidyr",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.8.3",
+      "Hash": "51442fddca0f783dce03baffbe5b790b"
+    },
+    "tidyselect": {
+      "Package": "tidyselect",
+      "Version": "0.2.5",
+      "Source": "CRAN",
+      "Hash": "dc3fcbc21f04b293e0794e24982cf357"
+    },
+    "tiff": {
+      "Package": "tiff",
+      "Version": "0.1-5",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "tiff",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.1-5",
+      "Hash": "352d3426f348f884f7858db6cce080f7"
+    },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.15",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "tinytex",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.15",
+      "Hash": "11c9260eb54db1f55e7573844c2ae8ed"
+    },
+    "usethis": {
+      "Package": "usethis",
+      "Version": "1.5.1",
+      "Source": "CRAN",
+      "Hash": "d9554c06c56d30d6361b5b24b8c5b083"
+    },
+    "utf8": {
+      "Package": "utf8",
+      "Version": "1.1.4",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "utf8",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.1.4",
+      "Hash": "3f1a5a5b184f63379f8e6c08d5036c53"
+    },
+    "vctrs": {
+      "Package": "vctrs",
+      "Version": "0.2.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "vctrs",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.2.0",
+      "Hash": "4bdc6a6c4c5a434d880b73817d4ea641"
+    },
+    "viridisLite": {
+      "Package": "viridisLite",
+      "Version": "0.3.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "viridisLite",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "0.3.0",
+      "Hash": "1f264fa42320c4f44b1689d89101e823"
+    },
+    "webshot": {
+      "Package": "webshot",
+      "Version": "0.5.1",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "webshot",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.5.1",
+      "Hash": "751636e977781ba79331a00d96bfd7bd"
+    },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.3-2",
+      "Source": "CRAN",
+      "Hash": "c6d8a035a88c6e3222f0efaac18406f6"
+    },
+    "withr": {
+      "Package": "withr",
+      "Version": "2.1.2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "withr",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "2.1.2",
+      "Hash": "7c9aef08038f47e6c1532ed574a0e087"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.9",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "xfun",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.9",
+      "Hash": "f577b2b637a64f3b5662430ccc6fa1b7"
+    },
+    "xml2": {
+      "Package": "xml2",
+      "Version": "1.2.2",
+      "Source": "CRAN",
+      "Hash": "22fa8b694a7ffcec094bfb94a405595d"
+    },
+    "xopen": {
+      "Package": "xopen",
+      "Version": "1.0.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "xopen",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.0.0",
+      "Hash": "ec32d86b4bcfa2cfa648dc0e1e46e24d"
+    },
+    "xtable": {
+      "Package": "xtable",
+      "Version": "1.8-4",
+      "Source": "CRAN",
+      "Hash": "48f60fcc0974ce72870076d48038df2d"
+    },
+    "xts": {
+      "Package": "xts",
+      "Version": "0.11-2",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "xts",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.11-2",
+      "Hash": "f0e867bb5363b60e4c2e594653973af3"
+    },
+    "yaml": {
+      "Package": "yaml",
+      "Version": "2.2.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "yaml",
+      "RemoteRepos": "https://cran.rstudio.com",
+      "RemoteSha": "2.2.0",
+      "Hash": "3a313c96061c4ac790de611dc57ebd1f"
+    },
+    "yesno": {
+      "Package": "yesno",
+      "Version": "0.1.0",
+      "Source": "CRAN",
+      "Hash": "60425bff7e89ec3c31505ca8298bda01"
+    },
+    "zeallot": {
+      "Package": "zeallot",
+      "Version": "0.1.0",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "zeallot",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "0.1.0",
+      "Hash": "45d65588b02d47970fc84adecb2ee664"
+    },
+    "zoo": {
+      "Package": "zoo",
+      "Version": "1.8-6",
+      "Source": "CRAN",
+      "RemoteType": "standard",
+      "RemoteRef": "zoo",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteSha": "1.8-6",
+      "Hash": "6a408ac88994695f76d7b4f7f19c4006"
+    }
+  }
+}

--- a/renv/.gitignore
+++ b/renv/.gitignore
@@ -1,0 +1,2 @@
+library/
+python/

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -1,0 +1,160 @@
+
+local({
+
+  # the requested version of renv
+  version <- "0.6.0-92"
+
+  # signal that we're loading renv during R startup
+  Sys.setenv("RENV_R_INITIALIZING" = "true")
+  on.exit(Sys.unsetenv("RENV_R_INITIALIZING"), add = TRUE)
+
+  # load the 'utils' package eagerly -- this ensures that renv shims, which
+  # mask 'utils' packages, will come first on the search path
+  library(utils, lib.loc = .Library)
+
+  # check to see if renv has already been loaded
+  if ("renv" %in% loadedNamespaces()) {
+
+    # if renv has already been loaded, and it's the requested version of renv,
+    # nothing to do
+    spec <- .getNamespaceInfo(.getNamespace("renv"), "spec")
+    if (identical(spec$version, version))
+      return(invisible(TRUE))
+
+    # otherwise, unload and attempt to load the correct version of renv
+    unloadNamespace("renv")
+
+  }
+
+  # helper for sourcing the user profile (if any)
+  # respect R_PROFILE_USER when sourcing user profile
+  profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
+  source_user_profile <- function() {
+
+    if (!file.exists(profile))
+      return(FALSE)
+
+    # avoid recursion, in case user has activated a project in home directory
+    # (may occur in some Docker deployment configurations)
+    current <- normalizePath(".Rprofile", winslash = "/", mustWork = FALSE)
+    if (identical(normalizePath(profile, winslash = "/"), current))
+      return(FALSE)
+
+    # source with error handler
+    status <- tryCatch(source(profile), error = identity)
+    if (!inherits(status, "error"))
+      return(TRUE)
+
+    # report any errors to the user
+    prefix <- sprintf("Error sourcing %s:", profile)
+    message <- paste(prefix, conditionMessage(status))
+    warning(simpleWarning(message))
+
+  }
+
+  # load user profile now -- needs to happen before renv is loaded,
+  # as otherwise the user profile could clobber the library paths
+  # that renv tries to set up for the project
+  source_user_profile()
+
+  # figure out root for renv installation
+  default <- switch(
+    Sys.info()[["sysname"]],
+    Darwin  = Sys.getenv("XDG_DATA_HOME", "~/Library/Application Support"),
+    Windows = Sys.getenv("LOCALAPPDATA", "~/.renv"),
+    Sys.getenv("XDG_DATA_HOME", "~/.local/share")
+  )
+
+  base <- Sys.getenv("RENV_PATHS_ROOT", unset = file.path(default, "renv"))
+  rversion <- paste("R", getRversion()[1, 1:2], sep = "-")
+  path <- file.path(base, "bootstrap", rversion, R.version$platform, "renv", version)
+
+  # try to load renv from one of these paths
+  if (requireNamespace("renv", lib.loc = path, quietly = TRUE))
+    return(renv::load())
+
+  # failed to find renv locally; we'll try to install from GitHub.
+  # first, set up download options as appropriate (try to use GITHUB_PAT)
+  install_renv <- function() {
+
+    message("Failed to find installation of renv -- attempting to bootstrap...")
+
+    # ensure .Rprofile doesn't get executed
+    rpu <- Sys.getenv("R_PROFILE_USER", unset = NA)
+    Sys.setenv(R_PROFILE_USER = "<NA>")
+    on.exit({
+      if (is.na(rpu))
+        Sys.unsetenv("R_PROFILE_USER")
+      else
+        Sys.setenv(R_PROFILE_USER = rpu)
+    }, add = TRUE)
+
+    # prepare download options
+    pat <- Sys.getenv("GITHUB_PAT")
+    if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+      fmt <- "--location --fail --header \"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "curl", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+      fmt <- "--header=\"Authorization: token %s\""
+      extra <- sprintf(fmt, pat)
+      saved <- options("download.file.method", "download.file.extra")
+      options(download.file.method = "wget", download.file.extra = extra)
+      on.exit(do.call(base::options, saved), add = TRUE)
+    }
+
+    # fix up repos
+    repos <- getOption("repos")
+    on.exit(options(repos = repos), add = TRUE)
+    repos[repos == "@CRAN@"] <- "https://cran.rstudio.com"
+    options(repos = repos)
+
+    # check for renv on CRAN matching this version
+    db <- as.data.frame(available.packages(), stringsAsFactors = FALSE)
+    if ("renv" %in% rownames(db)) {
+      entry <- db["renv", ]
+      if (identical(entry$Version, version)) {
+        message("* Installing renv ", version, " ... ", appendLF = FALSE)
+        dir.create(path, showWarnings = FALSE, recursive = TRUE)
+        utils::install.packages("renv", lib = path, quiet = TRUE)
+        message("Done!")
+        return(TRUE)
+      }
+    }
+
+    # try to download renv
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+    prefix <- "https://api.github.com"
+    url <- file.path(prefix, "repos/rstudio/renv/tarball", version)
+    destfile <- tempfile("renv-", fileext = ".tar.gz")
+    on.exit(unlink(destfile), add = TRUE)
+    utils::download.file(url, destfile = destfile, mode = "wb", quiet = TRUE)
+    message("Done!")
+
+    # attempt to install it into bootstrap library
+    message("* Installing renv ", version, " ... ", appendLF = FALSE)
+    dir.create(path, showWarnings = FALSE, recursive = TRUE)
+    utils::install.packages(destfile, repos = NULL, type = "source", lib = path, quiet = TRUE)
+    message("Done!")
+
+  }
+
+  try(install_renv())
+
+  # try again to load
+  if (requireNamespace("renv", lib.loc = path, quietly = TRUE)) {
+    message("Successfully installed and loaded renv ", version, ".")
+    return(renv::load())
+  }
+
+  # failed to download or load renv; warn the user
+  msg <- c(
+    "Failed to find an renv installation: the project will not be loaded.",
+    "Use `renv::activate()` to re-initialize the project."
+  )
+
+  warning(paste(msg, collapse = "\n"), call. = FALSE)
+
+})

--- a/renv/settings.dcf
+++ b/renv/settings.dcf
@@ -1,0 +1,4 @@
+external.libraries:
+ignored.packages:
+snapshot.type: packrat
+use.cache: TRUE


### PR DESCRIPTION
This PR adds [`renv`](https://rstudio.github.io/renv/index.html) to manage dependency packages and makes small updates for using the latest CRAN releases of `bs4Dash` and `golem`.